### PR TITLE
Fix rendering html tag in markdown

### DIFF
--- a/src/__snapshots__/index.test.js.snap
+++ b/src/__snapshots__/index.test.js.snap
@@ -196,6 +196,43 @@ exports[`should be able to compile list 1`] = `
 </div>
 `;
 
+exports[`should be able to compile list with html tag 1`] = `
+<div>
+  <font
+    color="red"
+  >
+     this is root red text 
+  </font>
+  <ul>
+    <li>
+      list 1
+    </li>
+    <li>
+      list 2
+    </li>
+    <li>
+      <font
+        color="blue"
+      >
+        list blue text
+      </font>
+    </li>
+    <li>
+      list 3
+      <ul>
+        <li>
+          <font
+            color="green"
+          >
+            two depth green text
+          </font>
+        </li>
+      </ul>
+    </li>
+  </ul>
+</div>
+`;
+
 exports[`should be able to compile nested lists 1`] = `
 <div>
   <ul>

--- a/src/components.js
+++ b/src/components.js
@@ -16,6 +16,9 @@ export function marksy(options = {}) {
   const renderer = createRenderer(tracker, options, {
     html(html) {
       try {
+        // eslint-disable-next-line no-plusplus
+        const elementId = tracker.nextElementId++;
+
         const { code } = transform(html, {
           presets: ['react'],
         });
@@ -35,16 +38,20 @@ export function marksy(options = {}) {
           },
         };
 
-        tracker.tree.push(
-          // eslint-disable-next-line no-new-func
-          new Function('React', ...Object.keys(options.components), `return ${code}`)(
-            mockedReact,
-            ...components
-          ) || null
-        );
+        tracker.elements[elementId] =
+            // eslint-disable-next-line no-new-func
+            new Function('React', ...Object.keys(options.components), `return ${code}`)(
+                mockedReact,
+                ...components
+            ) || null;
+
+        tracker.tree.push(tracker.elements[elementId]);
+
+        return `{{${elementId}}}`;
       } catch (e) {
         //
       }
+      return null;
     },
     code(code, language) {
       if (language === 'marksy') {

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -478,3 +478,24 @@ it('should highlight code with Prism.js', () => {
 
   expect(tree).toMatchSnapshot();
 });
+
+it('should be able to compile list with html tag', () => {
+  const compile = marksyComponents({
+      createElement,
+  });
+
+  const compiled = compile(
+    `
+  <font color="red"> this is root red text </font>
+
+  * list 1
+  * list 2
+  * <font color="blue">list blue text</font>
+  * list 3
+    * <font color="green">two depth green text</font>
+  `);
+
+  const tree = renderer.create(<TestComponent>{compiled.tree}</TestComponent>).toJSON();
+
+  expect(tree).toMatchSnapshot();
+});


### PR DESCRIPTION
## Source Markdown

(I add one space on end of javascript code block(const clause) because without space it rendered as valid code block, so breaks rendering result)

```
# Some blog title

Just need to show you some code first:

```js
const foo = "bar"
`` `

<font color="red"> this is root red text </font>

* list 1
* list 2
* <font color="blue">list blue text</font>
* list 3
   * <font color="green">two depth green text</font>


<Row>
  <Col>Need to tell you something over here</Col>
  <Col>And over here</Col>
</Row>
```

## Before this pr

![image](https://user-images.githubusercontent.com/4811664/29267515-01b20f7c-8124-11e7-8574-0c2775fff333.png)


## After this pr

![image](https://user-images.githubusercontent.com/4811664/29267469-d3e1c5e2-8123-11e7-98bd-2a88058f5c24.png)
