### PR TITLE
Fix crash issue when markdown code contains language that unsupported by highlight.js

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,6 +72,9 @@
     "webpack": "^3.10.0",
     "webpack-dev-server": "^2.11.1"
   },
+  "jest": {
+    "testEnvironment": "node"
+  },
   "size-limit": [
     {
       "path": "lib/index.js",

--- a/src/__snapshots__/index.test.js.snap
+++ b/src/__snapshots__/index.test.js.snap
@@ -465,6 +465,16 @@ exports[`should highlight code with highlight.js 1`] = `
 </div>
 `;
 
+exports[`should not crash highlight.js with unsupported language 1`] = `
+<div>
+  <pre>
+    <code>
+      const foo = "bar"
+    </code>
+  </pre>
+</div>
+`;
+
 exports[`should produce TOC 1`] = `
 "[
   {

--- a/src/createRenderer.js
+++ b/src/createRenderer.js
@@ -3,11 +3,10 @@ import he from 'he';
 
 export function codeRenderer(tracker, options) {
   function CodeComponent(props) {
-    return options.createElement(
-      'pre',
-      null,
+    let children;
+    try {
       // eslint-disable-next-line react/no-danger-with-children
-      options.createElement(
+      children = options.createElement(
         'code',
         {
           className: `language-${props.language}`,
@@ -16,8 +15,14 @@ export function codeRenderer(tracker, options) {
             : null,
         },
         options.highlight ? null : props.code
-      )
-    );
+      );
+    } catch (e) {
+      // eslint-disable-next-line
+      console.warn(`${props.language} is not highlight support language.`);
+      children = options.createElement('code', null, props.code);
+    }
+
+    return options.createElement('pre', null, children);
   }
 
   return (code, language) => {

--- a/src/createRenderer.js
+++ b/src/createRenderer.js
@@ -18,7 +18,7 @@ export function codeRenderer(tracker, options) {
       );
     } catch (e) {
       // eslint-disable-next-line
-      console.warn(`${props.language} is not highlight support language.`);
+      console.warn(`${props.language} is not supported by your defined highlighter.`);
       children = options.createElement('code', null, props.code);
     }
 

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -465,6 +465,21 @@ it('should highlight code with highlight.js', () => {
   expect(tree).toMatchSnapshot();
 });
 
+it('should not crash highlight.js with unsupported language', () => {
+  const compile = marksy({
+    createElement,
+    highlight(language, code) {
+      return hljs.highlight(language, code).value;
+    },
+  });
+
+  const compiled = compile('```unsuppoted_language\nconst foo = "bar"\n```');
+
+  const tree = renderer.create(<TestComponent>{compiled.tree}</TestComponent>).toJSON();
+
+  expect(tree).toMatchSnapshot();
+});
+
 it('should highlight code with Prism.js', () => {
   const compile = marksyComponents({
     createElement,


### PR DESCRIPTION
This code makes crash on example application. (and other applications too)

\`\`\` js2
const foo = "bar"
\`\`\`


I added fallback routine when highlight.js throws unsupported language error.