### PR TITLE
Update README to import with /jsx instead of /components

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ compiled.toc // The table of contents, based on usage of headers
 ```
 
 ### Components
-You can also add your own custom components. You do this by importing `marksy/components`. This build of marksy includes babel transpiler which will convert any HTML to elements and allow for custom components:
+You can also add your own custom components. You do this by importing `marksy/jsx`. This build of marksy includes babel transpiler which will convert any HTML to elements and allow for custom components:
 
 <pre lang="js"><code>
 import React, {createElement} from 'react'
@@ -118,7 +118,7 @@ You might need to pass in general information to your custom elements and compon
 
 ```js
 import React, {createElement} from 'react'
-import marksy from 'marksy/components'
+import marksy from 'marksy/jsx'
 
 const compile = marksy({
   createElement,
@@ -147,7 +147,7 @@ import {createElement} from 'react'
 import 'highlight.js/styles/github.css';
 import hljs from 'highlight.js/lib/highlight';
 import hljsJavascript from 'highlight.js/lib/languages/javascript';
-import marksy from 'marksy/components'
+import marksy from 'marksy/jsx'
 
 hljs.registerLanguage('javascript', hljsJavascript);
 

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ You can take one step further and create components wherever you want in the mar
 
 <pre lang="js"><code>
 import React, {createElement} from 'react'
-import marksy from 'marksy/components'
+import marksy from 'marksy/jsx'
 
 const compile = marksy({
   createElement,


### PR DESCRIPTION
The `marksy/components` import is [deprecated](https://github.com/storybooks/marksy/blob/d2f120c21abd0d3af8a573aeee6dc95a0aef2b32/components.js#L2) but is still the import being used in the code examples.